### PR TITLE
use jinja comment filter for ansible_managed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
     path: /etc/sudoers.d
     owner: root
     group: root
-    mode: 0755
+    mode: 0750
     state: directory
 
 - name: Set includedir in sudoers

--- a/templates/sudoers.d.j2
+++ b/templates/sudoers.d.j2
@@ -1,4 +1,5 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
+
 {% for sudoer in sudoers %}
 {{ sudoer.user }}  {% if sudoer.host is defined %}{{ sudoer.host }}{% else %}ALL{% endif %}={% if sudoer.user_commands is defined %}{% for user_command in sudoer.user_commands %}{% if user_command.runas_users is defined %}({{ user_command.runas_users|join(', ') }}){% else %}(ALL){% endif %}{% if user_command.nopasswd %} NOPASSWD: {% else %} PASSWD: {% endif %}{{ user_command.commands|join(', ') }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}(ALL) PASSWD: ALL{% endif %}
 


### PR DESCRIPTION
for multiline ``ansible_managed` lines the template is broken

```
ansible_managed = This file is managed by Ansible.%n
  template: {file}
  date: %Y-%m-%d %H:%M:%S
  user: {uid}
  host: {host}
```